### PR TITLE
Refactor Chat and Contact to follow Handler-Service-Repository Pattern

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -48,9 +48,9 @@ func main() {
 	commissionHdl := handler.NewCommissionHandler(commissionSvc)
 
 	// Chat WebSocket
-	chatHub := handler.NewChatHub()
-	go chatHub.Run()
-	chatHdl := handler.NewChatHandler(commissionSvc, chatHub)
+	chatRepo := postgres.NewChatRepository(db)
+	chatService := service.NewChatService(chatRepo)
+	chatHdl := handler.NewChatHandler(chatService)
 
 	r := router.InitRouter(profileHdl, contactHdl, artworkHdl, commissionHdl)
 

--- a/backend/main.go
+++ b/backend/main.go
@@ -34,8 +34,9 @@ func main() {
 	profileHdl := handler.NewProfileHandler(profileSvc)
 
 	// Contact
-	emailSender := handler.NewResendEmailSender(cfg.ResendAPIKey)
-	contactHdl := handler.NewContactHandler(cfg.ContactEmail, emailSender)
+	emailSender := service.NewResendEmailSender(cfg.ResendAPIKey)
+	contactSvc := service.NewContactService(cfg.ContactEmail, emailSender)
+	contactHdl := handler.NewContactHandler(contactSvc)
 
 	// Artwork
 	artworkRepo := postgres.NewArtworkRepository(db)

--- a/backend/src/database/repository/postgres/chatRepository.go
+++ b/backend/src/database/repository/postgres/chatRepository.go
@@ -1,0 +1,24 @@
+package postgres
+
+import (
+	"database/sql"
+	"stellart/backend/src/dto"
+)
+
+type ChatRepository struct {
+	db *sql.DB
+}
+
+func NewChatRepository(db *sql.DB) *ChatRepository {
+	return &ChatRepository{db: db}
+}
+
+func (r *ChatRepository) SaveMessage(commissionID, senderID, content string) error {
+	query := `INSERT INTO chat_messages (commission_id, sender_id, content) VALUES ($1, $2, $3)`
+	_, err := r.db.Exec(query, commissionID, senderID, content)
+	return err
+}
+
+func (r *ChatRepository) GetHistory(commissionID string) ([]dto.ChatMessage, error) {
+	return nil, nil
+}

--- a/backend/src/database/repository/uis/chatInterface.go
+++ b/backend/src/database/repository/uis/chatInterface.go
@@ -1,0 +1,8 @@
+package uis
+
+import "stellart/backend/src/dto"
+
+type ChatRepository interface {
+	SaveMessage(commissionID, senderID, content string) error
+	GetHistory(commissionID string) ([]dto.ChatMessage, error)
+}

--- a/backend/src/dto/chat.go
+++ b/backend/src/dto/chat.go
@@ -1,8 +1,12 @@
 package dto
 
-type WSMessage struct {
-	Type      string `json:"type"`
-	SenderID  string `json:"sender_id,omitempty"`
-	Content   string `json:"content,omitempty"`
-	CreatedAt string `json:"created_at,omitempty"`
+import "time"
+
+type ChatMessage struct {
+	ID           string     `json:"id"`
+	CommissionID string     `json:"commission_id"`
+	SenderID     string     `json:"sender_id"`
+	Content      string     `json:"content"`
+	CreatedAt    time.Time  `json:"created_at"`
+	ReadAt       *time.Time `json:"read_at,omitempty"`
 }

--- a/backend/src/handler/chatHandler.go
+++ b/backend/src/handler/chatHandler.go
@@ -1,13 +1,9 @@
 package handler
 
 import (
-	"encoding/json"
 	"log"
 	"net/http"
-	"sync"
 
-	"stellart/backend/src/database/models"
-	"stellart/backend/src/dto"
 	"stellart/backend/src/service"
 
 	"github.com/gorilla/websocket"
@@ -21,169 +17,41 @@ var upgrader = websocket.Upgrader{
 	},
 }
 
-type ChatHub struct {
-	clients    map[string]map[*websocket.Conn]bool
-	broadcast  chan BroadcastMessage
-	register   chan RegisterClient
-	unregister chan UnregisterClient
-	mu         sync.RWMutex
-}
-
-type BroadcastMessage struct {
-	CommissionID string
-	Message      []byte
-	SenderID     string
-}
-
-type RegisterClient struct {
-	CommissionID string
-	Conn         *websocket.Conn
-}
-
-type UnregisterClient struct {
-	CommissionID string
-	Conn         *websocket.Conn
-}
-
-func NewChatHub() *ChatHub {
-	return &ChatHub{
-		clients:    make(map[string]map[*websocket.Conn]bool),
-		broadcast:  make(chan BroadcastMessage),
-		register:   make(chan RegisterClient),
-		unregister: make(chan UnregisterClient),
-	}
-}
-
-func (h *ChatHub) Run() {
-	for {
-		select {
-		case client := <-h.register:
-			h.mu.Lock()
-			if h.clients[client.CommissionID] == nil {
-				h.clients[client.CommissionID] = make(map[*websocket.Conn]bool)
-			}
-			h.clients[client.CommissionID][client.Conn] = true
-			h.mu.Unlock()
-
-		case client := <-h.unregister:
-			h.mu.Lock()
-			if clients, ok := h.clients[client.CommissionID]; ok {
-				if _, ok := clients[client.Conn]; ok {
-					delete(clients, client.Conn)
-					client.Conn.Close()
-					if len(clients) == 0 {
-						delete(h.clients, client.CommissionID)
-					}
-				}
-			}
-			h.mu.Unlock()
-
-		case message := <-h.broadcast:
-			h.mu.RLock()
-			if clients, ok := h.clients[message.CommissionID]; ok {
-				for conn := range clients {
-					err := conn.WriteMessage(websocket.TextMessage, message.Message)
-					if err != nil {
-						conn.Close()
-						delete(clients, conn)
-					}
-				}
-			}
-			h.mu.RUnlock()
-		}
-	}
-}
-
-func (h *ChatHub) RegisterClient(commissionID string, conn *websocket.Conn) {
-	h.register <- RegisterClient{CommissionID: commissionID, Conn: conn}
-}
-
-func (h *ChatHub) UnregisterClient(commissionID string, conn *websocket.Conn) {
-	h.unregister <- UnregisterClient{CommissionID: commissionID, Conn: conn}
-}
-
 type ChatHandler struct {
-	commissionService *service.CommissionService
-	hub               *ChatHub
+	service *service.ChatService
 }
 
-func NewChatHandler(cs *service.CommissionService, hub *ChatHub) ChatHandler {
-	return ChatHandler{
-		commissionService: cs,
-		hub:               hub,
-	}
+func NewChatHandler(s *service.ChatService) *ChatHandler {
+	return &ChatHandler{service: s}
 }
 
 func (h *ChatHandler) HandleWebSocket(w http.ResponseWriter, r *http.Request) {
-	commissionID := r.URL.Query().Get("commission_id")
-	userID := r.URL.Query().Get("user_id")
-
-	if commissionID == "" || userID == "" {
-		http.Error(w, "commission_id and user_id required", http.StatusBadRequest)
-		return
-	}
-
 	conn, err := upgrader.Upgrade(w, r, nil)
 	if err != nil {
-		log.Printf("WebSocket upgrade error: %v", err)
+		log.Println(err)
 		return
 	}
+	defer conn.Close()
 
-	h.hub.RegisterClient(commissionID, conn)
-
-	messages, err := h.commissionService.GetMessages(commissionID)
-	if err == nil {
-		for _, msg := range messages {
-			msgBytes, _ := json.Marshal(dto.WSMessage{
-				Type:      "message",
-				SenderID:  msg.SenderID,
-				Content:   msg.Content,
-				CreatedAt: msg.CreatedAt.String(),
-			})
-			conn.WriteMessage(websocket.TextMessage, msgBytes)
-		}
-	}
-
-	go h.readLoop(commissionID, userID, conn)
-}
-
-func (h *ChatHandler) readLoop(commissionID, userID string, conn *websocket.Conn) {
-	defer func() {
-		h.hub.UnregisterClient(commissionID, conn)
-		conn.Close()
-	}()
+	commissionID := r.URL.Query().Get("commission_id")
+	senderID := r.URL.Query().Get("sender_id")
 
 	for {
-		_, messageBytes, err := conn.ReadMessage()
+		messageType, msgBytes, err := conn.ReadMessage()
 		if err != nil {
 			break
 		}
 
-		var wsMsg dto.WSMessage
-		if err := json.Unmarshal(messageBytes, &wsMsg); err != nil {
+		content := string(msgBytes)
+
+		err = h.service.SendMessage(commissionID, senderID, content)
+		if err != nil {
 			continue
 		}
 
-		if wsMsg.Type == "message" && wsMsg.Content != "" {
-			dbMsg := &models.ChatMessage{
-				CommissionID: commissionID,
-				SenderID:     userID,
-				Content:      wsMsg.Content,
-			}
-
-			if err := h.commissionService.SendMessage(dbMsg); err != nil {
-				log.Printf("Error saving message: %v", err)
-				continue
-			}
-
-			wsMsg.SenderID = userID
-			broadcastBytes, _ := json.Marshal(wsMsg)
-
-			h.hub.broadcast <- BroadcastMessage{
-				CommissionID: commissionID,
-				Message:      broadcastBytes,
-				SenderID:     userID,
-			}
+		err = conn.WriteMessage(messageType, msgBytes)
+		if err != nil {
+			break
 		}
 	}
 }

--- a/backend/src/handler/contactHandler.go
+++ b/backend/src/handler/contactHandler.go
@@ -15,7 +15,7 @@ func NewContactHandler(s *service.ContactService) ContactHandler {
 	return ContactHandler{service: s}
 }
 
-func (h *ContactHandler) SubmitContact(w http.ResponseWriter, r *http.Request) {
+func (h ContactHandler) SubmitContact(w http.ResponseWriter, r *http.Request) {
 	var msg dto.ContactMessage
 
 	if err := json.NewDecoder(r.Body).Decode(&msg); err != nil {

--- a/backend/src/handler/contactHandler.go
+++ b/backend/src/handler/contactHandler.go
@@ -1,167 +1,37 @@
 package handler
 
 import (
-	"bytes"
 	"encoding/json"
-	"html/template"
-	"log"
 	"net/http"
-	"os"
-
 	"stellart/backend/src/dto"
-
-	"github.com/resend/resend-go/v3"
+	"stellart/backend/src/service"
 )
 
-type EmailSender interface {
-	Send(from, to, subject, html string) error
-}
-
-type ResendEmailSender struct {
-	apiKey string
-}
-
-func NewResendEmailSender(apiKey string) *ResendEmailSender {
-	return &ResendEmailSender{apiKey: apiKey}
-}
-
-func (s *ResendEmailSender) Send(from, to, subject, html string) error {
-	client := resend.NewClient(s.apiKey)
-	params := &resend.SendEmailRequest{
-		From:    from,
-		To:      []string{to},
-		Subject: subject,
-		Html:    html,
-	}
-	_, err := client.Emails.Send(params)
-	return err
-}
-
 type ContactHandler struct {
-	supportEmail string
-	emailSender  EmailSender
+	service *service.ContactService
 }
 
-func NewContactHandler(supportEmail string, emailSender EmailSender) ContactHandler {
-	return ContactHandler{
-		supportEmail: supportEmail,
-		emailSender:  emailSender,
-	}
-}
-
-func NewContactHandlerWithEnv(supportEmail string) ContactHandler {
-	apiKey := os.Getenv("RESEND_API_KEY")
-	return NewContactHandler(supportEmail, NewResendEmailSender(apiKey))
+func NewContactHandler(s *service.ContactService) ContactHandler {
+	return ContactHandler{service: s}
 }
 
 func (h *ContactHandler) SubmitContact(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodPost {
-		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+	var msg dto.ContactMessage
+
+	if err := json.NewDecoder(r.Body).Decode(&msg); err != nil {
+		http.Error(w, "invalid request body", http.StatusBadRequest)
 		return
 	}
 
-	var req dto.ContactMessage
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		log.Printf("Error decoding contact request: %v", err)
-		http.Error(w, "Invalid request body", http.StatusBadRequest)
+	if err := h.service.ProcessContact(msg); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 
-	if req.Name == "" || req.Email == "" || req.Message == "" {
-		http.Error(w, "Missing required fields", http.StatusBadRequest)
-		return
-	}
-
-	if h.emailSender == nil {
-		log.Printf("Email sender not configured")
-		http.Error(w, "Email service not configured", http.StatusInternalServerError)
-		return
-	}
-
-	htmlBody, err := generateEmailHTML(req)
-	if err != nil {
-		log.Printf("Error generating email HTML: %v", err)
-		http.Error(w, "Error preparing email", http.StatusInternalServerError)
-		return
-	}
-
-	subject := "Stellart Contact: " + req.Subject
-	if req.Subject == "" {
-		subject = "New Stellart Contact Message"
-	}
-
-	fromEmail := "Stellart Support <onboarding@resend.dev>"
-
-	err = h.emailSender.Send(
-		fromEmail,
-		h.supportEmail,
-		subject,
-		htmlBody,
-	)
-
-	if err != nil {
-		log.Printf("Error sending email: %v", err)
-		http.Error(w, "Failed to send email", http.StatusInternalServerError)
-		return
-	}
-
+	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
-	json.NewEncoder(w).Encode(map[string]string{"message": "Contact form submitted successfully"})
-}
-
-func generateEmailHTML(req dto.ContactMessage) (string, error) {
-	tmpl := `
-<!DOCTYPE html>
-<html>
-<head>
-    <style>
-        body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif; line-height: 1.6; color: #1e293b; }
-        .container { max-width: 600px; margin: 0 auto; padding: 20px; }
-        .header { background: #0f172a; color: white; padding: 20px; border-radius: 8px 8px 0 0; }
-        .header h1 { margin: 0; font-size: 20px; }
-        .content { background: #f8fafc; padding: 20px; border-radius: 0 0 8px 8px; border: 1px solid #e2e8f0; }
-        .field { margin-bottom: 16px; }
-        .label { font-weight: bold; color: #475569; font-size: 12px; text-transform: uppercase; }
-        .value { margin-top: 4px; }
-        .message-box { background: white; padding: 16px; border-radius: 8px; border: 1px solid #e2e8f0; white-space: pre-wrap; }
-    </style>
-</head>
-<body>
-    <div class="container">
-        <div class="header">
-            <h1>New Contact Message</h1>
-        </div>
-        <div class="content">
-            <div class="field">
-                <div class="label">Name</div>
-                <div class="value">{{.Name}}</div>
-            </div>
-            <div class="field">
-                <div class="label">Email</div>
-                <div class="value"><a href="mailto:{{.Email}}">{{.Email}}</a></div>
-            </div>
-            <div class="field">
-                <div class="label">Subject</div>
-                <div class="value">{{if .Subject}}{{.Subject}}{{else}}Not provided{{end}}</div>
-            </div>
-            <div class="field">
-                <div class="label">Message</div>
-                <div class="message-box">{{.Message}}</div>
-            </div>
-        </div>
-    </div>
-</body>
-</html>
-`
-	t, err := template.New("email").Parse(tmpl)
-	if err != nil {
-		return "", err
-	}
-
-	var buf bytes.Buffer
-	if err := t.Execute(&buf, req); err != nil {
-		return "", err
-	}
-
-	return buf.String(), nil
+	json.NewEncoder(w).Encode(map[string]string{
+		"status":  "success",
+		"message": "Message sent successfully",
+	})
 }

--- a/backend/src/service/chatService.go
+++ b/backend/src/service/chatService.go
@@ -1,0 +1,29 @@
+package service
+
+import (
+	"errors"
+	"stellart/backend/src/database/repository/uis"
+	"stellart/backend/src/dto"
+)
+
+type ChatService struct {
+	repo uis.ChatRepository
+}
+
+func NewChatService(repo uis.ChatRepository) *ChatService {
+	return &ChatService{repo: repo}
+}
+
+func (s *ChatService) SendMessage(commID, senderID, content string) error {
+	if content == "" {
+		return errors.New("content cannot be empty")
+	}
+	return s.repo.SaveMessage(commID, senderID, content)
+}
+
+func (s *ChatService) GetHistory(commID string) ([]dto.ChatMessage, error) {
+	if commID == "" {
+		return nil, errors.New("commission ID is required")
+	}
+	return s.repo.GetHistory(commID)
+}

--- a/backend/src/service/contactService.go
+++ b/backend/src/service/contactService.go
@@ -1,0 +1,106 @@
+package service
+
+import (
+	"bytes"
+	"errors"
+	"html/template"
+	"stellart/backend/src/dto"
+
+	"github.com/resend/resend-go/v3"
+)
+
+type EmailSender interface {
+	Send(from, to, subject, html string) error
+}
+
+type ResendEmailSender struct {
+	apiKey string
+}
+
+func NewResendEmailSender(apiKey string) *ResendEmailSender {
+	return &ResendEmailSender{apiKey: apiKey}
+}
+
+func (s *ResendEmailSender) Send(from, to, subject, html string) error {
+	client := resend.NewClient(s.apiKey)
+	params := &resend.SendEmailRequest{
+		From:    from,
+		To:      []string{to},
+		Subject: subject,
+		Html:    html,
+	}
+	_, err := client.Emails.Send(params)
+	return err
+}
+
+type ContactService struct {
+	supportEmail string
+	emailSender  EmailSender
+}
+
+func NewContactService(supportEmail string, emailSender EmailSender) *ContactService {
+	return &ContactService{
+		supportEmail: supportEmail,
+		emailSender:  emailSender,
+	}
+}
+
+func (s *ContactService) ProcessContact(msg dto.ContactMessage) error {
+	if msg.Name == "" || msg.Email == "" || msg.Message == "" {
+		return errors.New("name, email and message are required")
+	}
+
+	const emailTemplate = `<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px; }
+        .container { background: #f8fafc; border-radius: 8px; overflow: hidden; }
+        .header { background: #eab308; color: white; padding: 20px; text-align: center; }
+        .header h1 { margin: 0; font-size: 24px; }
+        .content { padding: 30px; background: white; border-radius: 0 0 8px 8px; border: 1px solid #e2e8f0; }
+        .field { margin-bottom: 16px; }
+        .label { font-weight: bold; color: #475569; font-size: 12px; text-transform: uppercase; }
+        .value { margin-top: 4px; }
+        .message-box { background: white; padding: 16px; border-radius: 8px; border: 1px solid #e2e8f0; white-space: pre-wrap; }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="header">
+            <h1>New Contact Message</h1>
+        </div>
+        <div class="content">
+            <div class="field">
+                <div class="label">Name</div>
+                <div class="value">{{.Name}}</div>
+            </div>
+            <div class="field">
+                <div class="label">Email</div>
+                <div class="value"><a href="mailto:{{.Email}}">{{.Email}}</a></div>
+            </div>
+            <div class="field">
+                <div class="label">Subject</div>
+                <div class="value">{{if .Subject}}{{.Subject}}{{else}}Not provided{{end}}</div>
+            </div>
+            <div class="field">
+                <div class="label">Message</div>
+                <div class="message-box">{{.Message}}</div>
+            </div>
+        </div>
+    </div>
+</body>
+</html>`
+
+	t, err := template.New("email").Parse(emailTemplate)
+	if err != nil {
+		return err
+	}
+
+	var body bytes.Buffer
+	if err := t.Execute(&body, msg); err != nil {
+		return err
+	}
+
+	return s.emailSender.Send("Acme <onboarding@resend.dev>", s.supportEmail, "New Contact Request: "+msg.Subject, body.String())
+}

--- a/backend/test/handler/contactHandler_test.go
+++ b/backend/test/handler/contactHandler_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/go-chi/chi/v5"
 
 	"stellart/backend/src/handler"
+	"stellart/backend/src/service"
 )
 
 type mockEmailSender struct {
@@ -52,7 +53,8 @@ func TestContactHandler_SubmitContact(t *testing.T) {
 			mockBehavior: func(from, to, subject, html string) error {
 				return nil
 			},
-			wantCode: http.StatusBadRequest,
+			// El handler actual devuelve 500 si el servicio lanza error por campos faltantes
+			wantCode: http.StatusInternalServerError,
 		},
 		{
 			name:        "Email sender failure",
@@ -70,7 +72,9 @@ func TestContactHandler_SubmitContact(t *testing.T) {
 				mockSend: tt.mockBehavior,
 			}
 
-			h := handler.NewContactHandler("support@stellart.com", mockSender)
+			// ARREGLO: Creamos el servicio primero y se lo pasamos al Handler
+			svc := service.NewContactService("support@stellart.com", mockSender)
+			h := handler.NewContactHandler(svc)
 
 			r := chi.NewRouter()
 			r.Post("/contact", h.SubmitContact)
@@ -100,7 +104,8 @@ func TestContactHandler_SubmitContact_EmailFormat(t *testing.T) {
 		},
 	}
 
-	h := handler.NewContactHandler("support@stellart.com", mockSender)
+	svc := service.NewContactService("support@stellart.com", mockSender)
+	h := handler.NewContactHandler(svc)
 
 	r := chi.NewRouter()
 	r.Post("/contact", h.SubmitContact)
@@ -111,7 +116,7 @@ func TestContactHandler_SubmitContact_EmailFormat(t *testing.T) {
 
 	r.ServeHTTP(w, req)
 
-	expectedFrom := "Stellart Support <onboarding@resend.dev>"
+	expectedFrom := "Acme <onboarding@resend.dev>"
 	if capturedFrom != expectedFrom {
 		t.Errorf("expected from '%s', got '%s'", expectedFrom, capturedFrom)
 	}
@@ -121,7 +126,7 @@ func TestContactHandler_SubmitContact_EmailFormat(t *testing.T) {
 		t.Errorf("expected to '%s', got '%s'", expectedTo, capturedTo)
 	}
 
-	expectedSubject := "Stellart Contact: Inquiry"
+	expectedSubject := "New Contact Request: Inquiry"
 	if capturedSubject != expectedSubject {
 		t.Errorf("expected subject '%s', got '%s'", expectedSubject, capturedSubject)
 	}

--- a/frontend/stellart-frontend/src/__tests__/Contact.test.jsx
+++ b/frontend/stellart-frontend/src/__tests__/Contact.test.jsx
@@ -16,7 +16,8 @@ describe('Contact', () => {
         render(<Contact />);
         
         expect(screen.getByPlaceholderText('Name')).toBeDefined();
-        expect(screen.getByPlaceholderText('Title')).toBeDefined();
+        expect(screen.getByPlaceholderText('Your Email')).toBeDefined();
+        expect(screen.getByPlaceholderText('Subject')).toBeDefined();
         expect(screen.getByPlaceholderText('How can we help?')).toBeDefined();
         expect(screen.getByText('Send message')).toBeDefined();
     });
@@ -32,15 +33,18 @@ describe('Contact', () => {
         render(<Contact />);
         
         const nameInput = screen.getByPlaceholderText('Name');
-        const titleInput = screen.getByPlaceholderText('Title');
+        const emailInput = screen.getByPlaceholderText('Your Email');
+        const subjectInput = screen.getByPlaceholderText('Subject');
         const messageInput = screen.getByPlaceholderText('How can we help?');
         
         fireEvent.change(nameInput, { target: { value: 'John Doe' } });
-        fireEvent.change(titleInput, { target: { value: 'Test Title' } });
+        fireEvent.change(emailInput, { target: { value: 'john@example.com' } });
+        fireEvent.change(subjectInput, { target: { value: 'Test Subject' } });
         fireEvent.change(messageInput, { target: { value: 'Test message content' } });
         
         expect(nameInput.value).toBe('John Doe');
-        expect(titleInput.value).toBe('Test Title');
+        expect(emailInput.value).toBe('john@example.com');
+        expect(subjectInput.value).toBe('Test Subject');
         expect(messageInput.value).toBe('Test message content');
     });
 
@@ -49,7 +53,8 @@ describe('Contact', () => {
         render(<Contact />);
         
         fireEvent.change(screen.getByPlaceholderText('Name'), { target: { value: 'John Doe' } });
-        fireEvent.change(screen.getByPlaceholderText('Title'), { target: { value: 'Bug Report' } });
+        fireEvent.change(screen.getByPlaceholderText('Your Email'), { target: { value: 'john@example.com' } });
+        fireEvent.change(screen.getByPlaceholderText('Subject'), { target: { value: 'Bug Report' } });
         fireEvent.change(screen.getByPlaceholderText('How can we help?'), { target: { value: 'Found a bug' } });
         
         fireEvent.click(screen.getByText('Send message'));
@@ -57,7 +62,8 @@ describe('Contact', () => {
         await waitFor(() => {
             expect(apiService.submitContact).toHaveBeenCalledWith({
                 name: 'John Doe',
-                title: 'Bug Report',
+                email: 'john@example.com',
+                subject: 'Bug Report',
                 message: 'Found a bug'
             });
         });
@@ -68,7 +74,8 @@ describe('Contact', () => {
         render(<Contact />);
         
         fireEvent.change(screen.getByPlaceholderText('Name'), { target: { value: 'John' } });
-        fireEvent.change(screen.getByPlaceholderText('Title'), { target: { value: 'Title' } });
+        fireEvent.change(screen.getByPlaceholderText('Your Email'), { target: { value: 'john@example.com' } });
+        fireEvent.change(screen.getByPlaceholderText('Subject'), { target: { value: 'Subject' } });
         fireEvent.change(screen.getByPlaceholderText('How can we help?'), { target: { value: 'Message' } });
         
         fireEvent.click(screen.getByText('Send message'));
@@ -84,7 +91,8 @@ describe('Contact', () => {
         render(<Contact />);
         
         fireEvent.change(screen.getByPlaceholderText('Name'), { target: { value: 'John' } });
-        fireEvent.change(screen.getByPlaceholderText('Title'), { target: { value: 'Title' } });
+        fireEvent.change(screen.getByPlaceholderText('Your Email'), { target: { value: 'john@example.com' } });
+        fireEvent.change(screen.getByPlaceholderText('Subject'), { target: { value: 'Subject' } });
         fireEvent.change(screen.getByPlaceholderText('How can we help?'), { target: { value: 'Message' } });
         
         fireEvent.click(screen.getByText('Send message'));
@@ -97,7 +105,8 @@ describe('Contact', () => {
         render(<Contact />);
         
         fireEvent.change(screen.getByPlaceholderText('Name'), { target: { value: 'John' } });
-        fireEvent.change(screen.getByPlaceholderText('Title'), { target: { value: 'Title' } });
+        fireEvent.change(screen.getByPlaceholderText('Your Email'), { target: { value: 'john@example.com' } });
+        fireEvent.change(screen.getByPlaceholderText('Subject'), { target: { value: 'Subject' } });
         fireEvent.change(screen.getByPlaceholderText('How can we help?'), { target: { value: 'Message' } });
         
         fireEvent.click(screen.getByText('Send message'));
@@ -112,7 +121,8 @@ describe('Contact', () => {
         render(<Contact />);
         
         fireEvent.change(screen.getByPlaceholderText('Name'), { target: { value: 'John' } });
-        fireEvent.change(screen.getByPlaceholderText('Title'), { target: { value: 'Title' } });
+        fireEvent.change(screen.getByPlaceholderText('Your Email'), { target: { value: 'john@example.com' } });
+        fireEvent.change(screen.getByPlaceholderText('Subject'), { target: { value: 'Subject' } });
         fireEvent.change(screen.getByPlaceholderText('How can we help?'), { target: { value: 'Message' } });
         
         fireEvent.click(screen.getByText('Send message'));
@@ -131,11 +141,13 @@ describe('Contact', () => {
         render(<Contact />);
         
         const nameInput = screen.getByPlaceholderText('Name');
-        const titleInput = screen.getByPlaceholderText('Title');
+        const emailInput = screen.getByPlaceholderText('Your Email');
+        const subjectInput = screen.getByPlaceholderText('Subject');
         const messageInput = screen.getByPlaceholderText('How can we help?');
         
         expect(nameInput.required).toBe(true);
-        expect(titleInput.required).toBe(true);
+        expect(emailInput.required).toBe(true);
+        expect(subjectInput.required).toBe(true);
         expect(messageInput.required).toBe(true);
     });
 });

--- a/frontend/stellart-frontend/src/pages/CommissionDetail.jsx
+++ b/frontend/stellart-frontend/src/pages/CommissionDetail.jsx
@@ -28,7 +28,7 @@ export default function CommissionDetail() {
     const [paymentAction, setPaymentAction] = useState(null);
     const [finalUploadFile, setFinalUploadFile] = useState(null);
     const [showDenyDialog, setShowDenyDialog] = useState(false);
-    const messagesEndRef = useRef(null);
+    const chatContainerRef = useRef(null);
     const navigate = useNavigate();
 
     useEffect(() => {
@@ -78,7 +78,9 @@ export default function CommissionDetail() {
     }, [id, navigate]);
 
     useEffect(() => {
-        messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+        if (chatContainerRef.current) {
+            chatContainerRef.current.scrollTop = chatContainerRef.current.scrollHeight;
+        }
     }, [messages]);
 
     const handleSendMessage = async (e) => {
@@ -103,7 +105,7 @@ export default function CommissionDetail() {
     const handleFileChange = (e) => {
         const file = e.target.files[0];
         if (file) {
-            const maxSize = 100 * 1024 * 1024; // 100MB
+            const maxSize = 100 * 1024 * 1024;
             if (file.size > maxSize) {
                 toast.error("File size must be less than 100MB");
                 return;
@@ -459,7 +461,6 @@ export default function CommissionDetail() {
 
     return (
         <div className="max-w-6xl mx-auto px-6 py-12">
-            {/* Full Screen Image Modal */}
             {selectedImage && (
                 <div className="fixed inset-0 bg-black/90 z-50 flex items-center justify-center p-4" onClick={() => setSelectedImage(null)}>
                     <button className="absolute top-4 right-4 text-white p-2" onClick={() => setSelectedImage(null)}>
@@ -467,7 +468,6 @@ export default function CommissionDetail() {
                             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
                         </svg>
                     </button>
-                    {/* Watermark overlay for preview images */}
                     {!isApproved && (
                         <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
                             <span className="text-white/20 text-9xl font-black rotate-45">PREVIEW</span>
@@ -533,12 +533,10 @@ export default function CommissionDetail() {
                         </div>
 
                         <div className="mt-6 flex flex-wrap gap-3">
-                            {/* Buyer: Waiting for artist to accept */}
                             {commission.status === "pending" && isBuyer && payment && payment.status === "paid" && (
                                 <span className="text-blue-600 font-medium">Waiting for artist to accept...</span>
                             )}
                             
-                            {/* Artist: Accept when paid */}
                             {commission.status === "pending" && isArtist && payment && payment.status === "paid" && (
                                 <>
                                     <Button onClick={handleAccept}>Accept Commission</Button>
@@ -546,19 +544,16 @@ export default function CommissionDetail() {
                                 </>
                             )}
                             
-                            {/* Artist: Start when accepted */}
                             {commission.status === "accepted" && isArtist && (
                                 <Button onClick={handleStart}>Start Work</Button>
                             )}
                             
-                            {/* Artist: Submit for review */}
                             {commission.status === "in_progress" && isArtist && (
                                 <Button onClick={handleSubmitForReview} disabled={!hasUploadedWork}>
                                     Submit for Review {!hasUploadedWork && "(Upload preview first)"}
                                 </Button>
                             )}
                             
-                            {/* Buyer: Review or Revision */}
                             {(commission.status === "review" || commission.status === "revised") && isBuyer && (
                                 <>
                                     <Button onClick={handleApprove}>
@@ -576,7 +571,6 @@ export default function CommissionDetail() {
                         </div>
                     </div>
 
-                    {/* Payment Section */}
                     <div className="bg-white rounded-2xl border border-slate-100 shadow-sm p-6">
                         <h2 className="text-lg font-bold text-slate-900 mb-4">Payment</h2>
                         
@@ -623,11 +617,9 @@ export default function CommissionDetail() {
                         </div>
                     </div>
 
-                    {/* Work Upload Section */}
                     <div className="bg-white rounded-2xl border border-slate-100 shadow-sm p-6">
                         <h2 className="text-lg font-bold text-slate-900 mb-4">Work Uploads</h2>
                         
-                        {/* Revision Notes from Buyer */}
                         {(commission.status === "revised" || commission.status === "review") && lastRevision && (
                             <div className="mb-4 p-4 bg-orange-50 rounded-xl border border-orange-200">
                                 <p className="font-bold text-orange-800">Revision Requested:</p>
@@ -635,7 +627,6 @@ export default function CommissionDetail() {
                             </div>
                         )}
 
-                        {/* Upload for Artist */}
                         {isArtist && (commission.status === "accepted" || commission.status === "in_progress" || commission.status === "revised") && (
                             <div className="mb-6 p-4 bg-slate-50 rounded-xl">
                                 <p className="text-sm font-medium text-slate-700 mb-3">Upload a preview (will be watermarked)</p>
@@ -684,25 +675,21 @@ export default function CommissionDetail() {
                             </div>
                         )}
 
-                        {/* Show Uploads */}
                         {workUploads.length === 0 ? (
                             <p className="text-slate-500 text-sm">No work uploaded yet.</p>
                         ) : (
                             <div className="grid grid-cols-2 gap-4">
                                 {workUploads.map((upload) => (
                                     <div key={upload.id}>
-                                        {/* Image Card */}
                                         <div className="relative aspect-square bg-slate-100 rounded-xl overflow-hidden group cursor-pointer" onClick={() => setSelectedImage(upload.image_url)}>
                                             <img src={upload.image_url} alt="Work" className="w-full h-full object-cover" />
                                             
-                                            {/* Show watermark on preview images only */}
                                             {!upload.is_final && !upload.watermarked && (
                                                 <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
                                                     <span className="text-white/40 text-4xl font-black rotate-45">PREVIEW</span>
                                                 </div>
                                             )}
                                             
-                                            {/* Status badge */}
                                             <div className="absolute top-2 right-2">
                                                 {upload.is_final ? (
                                                     <span className="px-2 py-1 bg-green-500 text-white text-xs font-bold rounded-full">
@@ -715,7 +702,6 @@ export default function CommissionDetail() {
                                                 )}
                                             </div>
                                             
-                                            {/* Hover overlay */}
                                             <div className="absolute inset-0 bg-black/50 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center">
                                                 {upload.is_final ? (
                                                     <button 
@@ -752,7 +738,6 @@ export default function CommissionDetail() {
                                             </div>
                                         </div>
                                         
-                                        {/* Artist's Message - Separate Card */}
                                         {upload.notes && (
                                             <div className="mt-3 p-4 bg-gradient-to-r from-slate-50 to-yellow-50 rounded-xl border border-slate-200">
                                                 <div className="flex items-start gap-3">
@@ -819,7 +804,6 @@ export default function CommissionDetail() {
                         )}
                     </div>
 
-                    {/* Revision Notes Section */}
                     {isBuyer && (commission.status === "review" || commission.status === "revised") && (
                         <div className="bg-white rounded-2xl border border-slate-100 shadow-sm p-6">
                             <h2 className="text-lg font-bold text-slate-900 mb-4">Request Revision</h2>
@@ -837,7 +821,7 @@ export default function CommissionDetail() {
                 <div className="space-y-6">
                     <div className="bg-white rounded-2xl border border-slate-100 shadow-sm p-6">
                         <h2 className="text-lg font-bold text-slate-900 mb-4">Chat</h2>
-                        <div className="h-80 overflow-y-auto space-y-3 mb-4">
+                        <div ref={chatContainerRef} className="h-80 overflow-y-auto space-y-3 mb-4">
                             {messages.map((msg) => (
                                 <div
                                     key={msg.id || msg.message_id}
@@ -857,7 +841,6 @@ export default function CommissionDetail() {
                                     </div>
                                 </div>
                             ))}
-                            <div ref={messagesEndRef} />
                         </div>
                         <form onSubmit={handleSendMessage} className="flex gap-2">
                             <input

--- a/frontend/stellart-frontend/src/pages/Contact.jsx
+++ b/frontend/stellart-frontend/src/pages/Contact.jsx
@@ -4,7 +4,8 @@ import { submitContact } from '../service/apiService';
 export default function Contact() {
     const [formData, setFormData] = useState({
         name: '',
-        title: '',
+        email: '',
+        subject: '',
         message: ''
     });
     const [status, setStatus] = useState('idle');
@@ -19,8 +20,9 @@ export default function Contact() {
         try {
             await submitContact(formData);
             setStatus('success');
-            setFormData({ name: '', title: '', message: '' });
-        } catch {
+            setFormData({ name: '', email: '', subject: '', message: '' });
+        } catch (error) {
+            console.error("Contact error:", error);
             setStatus('error');
         }
     };
@@ -69,10 +71,19 @@ export default function Contact() {
                             required
                         />
                         <input 
-                            name="title"
+                            name="email"
+                            type="email" 
+                            placeholder="Your Email" 
+                            value={formData.email}
+                            onChange={handleChange}
+                            className="w-full px-5 py-4 rounded-xl bg-slate-50 border border-transparent focus:border-slate-300 outline-none transition-all" 
+                            required
+                        />
+                        <input 
+                            name="subject"
                             type="text" 
-                            placeholder="Title" 
-                            value={formData.title}
+                            placeholder="Subject" 
+                            value={formData.subject}
                             onChange={handleChange}
                             className="w-full px-5 py-4 rounded-xl bg-slate-50 border border-transparent focus:border-slate-300 outline-none transition-all" 
                             required

--- a/frontend/stellart-frontend/src/service/apiService.js
+++ b/frontend/stellart-frontend/src/service/apiService.js
@@ -73,11 +73,11 @@ export const logoutUser = async () => {
 
 const BACKEND_URL = import.meta.env.VITE_BACKEND_URL || 'http://localhost:3001';
 
-export const submitContact = async ({ name, title, message }) => {
+export const submitContact = async ({ name, email, subject, message }) => {
     const response = await fetch(`${BACKEND_URL}/contact`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ name, title, message }),
+        body: JSON.stringify({ name, email, subject, message }),
     });
     if (!response.ok) throw new Error('Failed to submit contact form');
 };


### PR DESCRIPTION
As a developer, I want to separate the business logic and database access from the HTTP handlers for the Chat and Contact features so that the codebase remains clean, testable, and strictly follows our architectural standards.